### PR TITLE
Fix: VTT transcription hours place inclusion

### DIFF
--- a/src/predict.py
+++ b/src/predict.py
@@ -161,7 +161,7 @@ def write_vtt(transcript):
     result = ""
 
     for segment in transcript:
-        result += f"{format_timestamp(segment.start)} --> {format_timestamp(segment.end)}\n"
+        result += f"{format_timestamp(segment.start, always_include_hours=True)} --> {format_timestamp(segment.end)}\n"
         result += f"{segment.text.strip().replace('-->', '->')}\n"
         result += "\n"
 


### PR DESCRIPTION
Makes VTT transcriptions timestamps always include the number of hours into the audio clip at which the current segment is spoken. Submitted as per a user's request/notice of the inconsistency.